### PR TITLE
first pass update to known-1.0.0/php7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
-FROM php:5.6-fpm
+FROM php:7.2-fpm
 
 LABEL maintainer="hello@withknown.com"
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends mysql-client \
+ && apt-get install -y --no-install-recommends mariadb-client \
  && savedAptMark="$(apt-mark showmanual)" \
  && apt-get install -y --no-install-recommends \
       libfreetype6-dev \
       libicu-dev \
       libjpeg-dev \
       libmcrypt-dev \
+      libmcrypt-dev \
       libpng-dev \
       libxml2-dev \
  && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
- && docker-php-ext-install exif gd intl mcrypt opcache pdo_mysql zip json xmlrpc \
+ && docker-php-ext-install exif gd intl opcache pdo_mysql zip json xmlrpc \
+ && pecl install mcrypt-1.0.3 \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
  && apt-mark auto '.*' > /dev/null \
  && apt-mark manual $savedAptMark \
@@ -39,10 +41,10 @@ RUN { \
 } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # PECL extensions
-RUN pecl install APCu-4.0.11 \
- && docker-php-ext-enable apcu
+RUN pecl install APCu-5.1.18 \
+ && docker-php-ext-enable apcu mcrypt
 
-ENV KNOWN_VERSION 0.9.9
+ENV KNOWN_VERSION 1.0.0
 VOLUME /var/www/html
 
 RUN fetchDeps=" \
@@ -51,12 +53,14 @@ RUN fetchDeps=" \
   " \
  && apt-get update \
  && apt-get install -y --no-install-recommends $fetchDeps \
- && curl -o known.tgz -fSL http://assets.withknown.com/releases/known-${KNOWN_VERSION}.tgz \
- && curl -o known.tgz.sig -fSL http://assets.withknown.com/releases/known-${KNOWN_VERSION}.tgz.sig \
+ && curl -o known.tgz -fSL https://withknown.marcus-povey.co.uk/known-${KNOWN_VERSION}.tgz \
+ && curl -o known.tgz.sha256 -fSL https://withknown.marcus-povey.co.uk/known-${KNOWN_VERSION}.tgz.sha256 \
+ && curl -o known.tgz.sha256.gpg -fSL https://withknown.marcus-povey.co.uk/known-${KNOWN_VERSION}.tgz.sha256.gpg \
  && export GNUPGHOME="$(mktemp -d)" \
-#gpg key from hello@withknown.com
- && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "53DE 5B99 2244 9132 8B92 7516 052D B5AC 742E 3B47" \
- && gpg --batch --verify known.tgz.sig known.tgz \
+#gpg key from marcus@marcus-povey.co.uk
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "E3F1C15C43A1E393A4B88C6E20FD53C2397813CA" \
+ && gpg --batch --verify known.tgz.sha256.gpg known.tgz.sha256 \
+ # && sha256sum hmm the sha256 file is binary and too large
  && mkdir /usr/src/known \
  && tar -xf known.tgz -C /usr/src/known \
  && rm -r "$GNUPGHOME" known.tgz* \


### PR DESCRIPTION
It builds but is untested.

Issues: 
 - Uses tar from @mapkyca's site, is that final?
 - Couldn't figure out what to do with the binary .sha256. Isn't it supposed to be in hex? Also the key you have linked at https://www.marcus-povey.co.uk/known/ (EC8148CF845C2043948FFF81BACB0C9AAA54ED56) isn't the signing key (E3F1C15C43A1E393A4B88C6E20FD53C2397813CA)

Changes:
 - Mariadb client since no mysql in buster
 - mcrypt moved to pecl

I know nothing about modern PHP so please advise what else should be changed,
or just fix this up for me :D